### PR TITLE
Require newer version of fdm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 requirements = [
     "numpy>=1.16",
-    "fdm",
+    "fdm>=0.5.0",
     "algebra>=1",
     "plum-dispatch>=2",
     "backends>=1.4.11",


### PR DESCRIPTION
Hey @wesselb

In https://github.com/wesselb/fdm/pull/1 we fixed some numpy compatibility issues in fdm that were released in version 0.5.0 but since fdm isn't a direct dependency of DeepSensor we're finding these issues still cropping up.

Since numpy 2 is here to stay, I wonder if we could restrict the version of fdm used by this package to the more broadly compatible version.

Sorry to be chasing you around all of your packages with this!